### PR TITLE
Update fork

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,7 +4,7 @@ inherit_gem:
   rubocop-jekyll: .rubocop.yml
 
 AllCops:
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.4
   Include:
     - lib/**/*.rb
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: ruby
 cache: bundler
 rvm:
-  - &latest_ruby 2.6
-  - 2.4
-  - 2.3
+  - &latest_ruby 2.7
+  - 2.5
 env:
   global:
     - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
@@ -12,9 +11,9 @@ env:
 matrix:
   include:
     - rvm: *latest_ruby
-      env: JEKYLL_VERSION="~> 3.7.4"
+      env: JEKYLL_VERSION="~> 3.8.6"
     - rvm: *latest_ruby
-      env: JEKYLL_VERSION=">= 4.0.0.pre.alpha1"
+      env: JEKYLL_VERSION=">= 4.0.0"
 before_install:
 - gem update --system
 - gem install bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ env:
   global:
     - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
   matrix:
-    - JEKYLL_VERSION="~> 3.8"
+    - JEKYLL_VERSION="~> 3.9"
 matrix:
   include:
     - rvm: *latest_ruby

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ source "https://rubygems.org"
 gemspec
 
 gem "jekyll", ENV["JEKYLL_VERSION"] if ENV["JEKYLL_VERSION"]
+gem "kramdown-parser-gfm" if ENV["JEKYLL_VERSION"] == "~> 3.9"
 
 install_if -> { Gem.win_platform? } do
   gem "tzinfo", "~> 1.2"

--- a/History.markdown
+++ b/History.markdown
@@ -7,6 +7,7 @@
 ### Minor Enhancements
 
   * Excerpt only flag (#287)
+  * Add media:content tag (#290)
 
 ## 0.12.1 / 2019-03-23
 

--- a/History.markdown
+++ b/History.markdown
@@ -1,3 +1,9 @@
+## HEAD
+
+### Bug Fixes
+
+  * Fix feed link when post title contains HTML (#305)
+
 ## 0.13.0 / 2019-11-13
 
 ### Minor Enhancements

--- a/History.markdown
+++ b/History.markdown
@@ -8,6 +8,7 @@
 
   * XML escape the title field of feed_meta (#306)
   * Make posts limit configurable (#314)
+  * Dont forget about categories (#233)
 
 ### Development Fixes
 

--- a/History.markdown
+++ b/History.markdown
@@ -4,6 +4,10 @@
 
   * test: use categories in post (#249)
 
+### Minor Enhancements
+
+  * Excerpt only flag (#287)
+
 ## 0.12.1 / 2019-03-23
 
   * Release: v0.12.0 (#271)

--- a/History.markdown
+++ b/History.markdown
@@ -1,3 +1,9 @@
+## HEAD
+
+### Development Fixes
+
+  * MetaTag: when encoding for XML special characters, handle non-string objects (#326)
+
 ## 0.15.0 / 2020-07-10
 
 ### Minor Enhancements

--- a/History.markdown
+++ b/History.markdown
@@ -10,6 +10,7 @@
   * Make posts limit configurable (#314)
   * Dont forget about categories (#233)
   * chore(deps): require Ruby &gt;=2.4.0 (#307)
+  * Feed by tag (#264)
 
 ### Development Fixes
 

--- a/History.markdown
+++ b/History.markdown
@@ -1,4 +1,4 @@
-## HEAD
+## 0.15.0 / 2020-07-10
 
 ### Minor Enhancements
 

--- a/History.markdown
+++ b/History.markdown
@@ -1,3 +1,9 @@
+## HEAD
+
+### Development Fixes
+
+  * test: use categories in post (#249)
+
 ## 0.12.1 / 2019-03-23
 
   * Release: v0.12.0 (#271)

--- a/History.markdown
+++ b/History.markdown
@@ -1,6 +1,8 @@
 ## HEAD
 
-### Development Fixes
+## 0.15.1 / 2020-10-04
+
+### Bug Fixes
 
   * MetaTag: when encoding for XML special characters, handle non-string objects (#326)
 

--- a/History.markdown
+++ b/History.markdown
@@ -9,6 +9,7 @@
   * XML escape the title field of feed_meta (#306)
   * Make posts limit configurable (#314)
   * Dont forget about categories (#233)
+  * chore(deps): require Ruby &gt;=2.4.0 (#307)
 
 ### Development Fixes
 

--- a/History.markdown
+++ b/History.markdown
@@ -7,6 +7,7 @@
 ### Minor Enhancements
 
   * XML escape the title field of feed_meta (#306)
+  * Make posts limit configurable (#314)
 
 ### Development Fixes
 

--- a/History.markdown
+++ b/History.markdown
@@ -1,3 +1,9 @@
+## HEAD
+
+### Minor Enhancements
+
+  * Add support for drafts (#316)
+
 ## 0.14.0 / 2020-06-24
 
 ### Minor Enhancements

--- a/History.markdown
+++ b/History.markdown
@@ -8,6 +8,10 @@
 
   * XML escape the title field of feed_meta (#306)
 
+### Development Fixes
+
+  * chore: use Dir to list source files (#309)
+
 ## 0.13.0 / 2019-11-13
 
 ### Minor Enhancements

--- a/History.markdown
+++ b/History.markdown
@@ -1,21 +1,20 @@
-## HEAD
+## 0.14.0 / 2020-06-24
+
+### Minor Enhancements
+
+  * add support for categories (#153) (#233)
+  * add support for tags (#264)
+  * Make posts limit configurable (#314)
+  * XML escape the title field of feed_meta (#306)
 
 ### Bug Fixes
 
   * Fix feed link when post title contains HTML (#305)
 
-### Minor Enhancements
-
-  * XML escape the title field of feed_meta (#306)
-  * Make posts limit configurable (#314)
-  * Dont forget about categories (#233)
-  * chore(deps): require Ruby &gt;=2.4.0 (#307)
-  * Feed by tag (#264)
-  * add support for categories frontmatter (#153)
-
 ### Development Fixes
 
-  * chore: use Dir to list source files (#309)
+  * Use Dir to list source files (#309)
+  * Require Ruby &gt;=2.4.0 (#307)
 
 ## 0.13.0 / 2019-11-13
 

--- a/History.markdown
+++ b/History.markdown
@@ -11,6 +11,7 @@
   * Dont forget about categories (#233)
   * chore(deps): require Ruby &gt;=2.4.0 (#307)
   * Feed by tag (#264)
+  * add support for categories frontmatter (#153)
 
 ### Development Fixes
 

--- a/History.markdown
+++ b/History.markdown
@@ -4,6 +4,10 @@
 
   * Fix feed link when post title contains HTML (#305)
 
+### Minor Enhancements
+
+  * XML escape the title field of feed_meta (#306)
+
 ## 0.13.0 / 2019-11-13
 
 ### Minor Enhancements

--- a/History.markdown
+++ b/History.markdown
@@ -1,17 +1,15 @@
-## HEAD
-
-### Development Fixes
-
-  * test: use categories in post (#249)
+## 0.13.0 / 2019-11-13
 
 ### Minor Enhancements
 
   * Excerpt only flag (#287)
   * Add media:content tag (#290)
 
-## 0.12.1 / 2019-03-23
+### Development Fixes
 
-  * Release: v0.12.0 (#271)
+  * test: use categories in post (#249)
+
+## 0.12.1 / 2019-03-23
 
 ### Bug Fixes
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The plugin will automatically use any of the following configuration variables, 
 
 * `title` or `name` - The title of the site, e.g., "My awesome site"
 * `description` - A longer description of what your site is about, e.g., "Where I blog about Jekyll and other awesome things"
-* `url` - The URL to your site, e.g., `http://example.com`. If none is provided, the plugin will try to use `site.github.url`.
+* `url` - The URL to your site, e.g., `https://example.com`. If none is provided, the plugin will try to use `site.github.url`.
 * `author` - Global author information (see below)
 
 ### Already have a feed path?

--- a/README.md
+++ b/README.md
@@ -205,6 +205,44 @@ feed:
 The same flag can be used directly in post file. It will be disable `<content>` tag for selected post.
 Settings in post file has higher priority than in config file.
 
+## Tags
+
+To automatically generate feeds for each tag you apply to your posts you can add a tags setting to your config:
+
+```yml
+feed:
+  tags: true
+```
+
+If there are tags you don't want included in this auto generation you can exclude them
+
+```yml
+feed:
+  tags:
+    except:
+      - tag-to-exclude
+      - another-tag
+```
+
+If you wish to change the location of these auto generated feeds (`/feed/by_tag/<TAG>.xml` by default) you can provide an alternative folder for them to live in.
+
+```yml
+feed:
+  tags:
+    path: "alternative/path/for/tags/feeds/"
+```
+
+If you only want to generate feeds for a few tags you can also set this.
+
+```yml
+feed:
+  tags:
+    only:
+      - tag-to-include
+      - another-tag
+```
+
+Note that if you include a tag that is excluded a feed will not be generated for it.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Jekyll's `smartify` filter uses [kramdown](https://kramdown.gettalong.org/option
 
 ### Custom styling
 
-Want to style what your feed looks like in the browser? When a XSLT Styleheet file named `feed.xslt.xml`exisrs at the root of your repository, a link to this stylesheet is added to the generated feed.
+Want to style what your feed looks like in the browser? When a XSLT Styleheet file named `feed.xslt.xml` exists at the root of your repository, a link to this stylesheet is added to the generated feed.
 
 ## Why Atom, and not RSS?
 

--- a/README.md
+++ b/README.md
@@ -151,6 +151,15 @@ feed:
     - updates
 ```
 
+## Posts limit
+
+By default the plugin limits the number of posts in the feed to 10. Simply define a new limit in your config:
+
+```yml
+feed:
+  posts_limit: 20
+```
+
 ## Collections
 
 Jekyll Feed can generate feeds for collections other than the Posts collection. This works best for chronological collections (e.g., collections with dates in the filenames). Simply define which collections you'd like feeds for in your config:

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Jekyll's `smartify` filter uses [kramdown](https://kramdown.gettalong.org/option
 
 ### Custom styling
 
-Want to style what your feed looks like in the browser? Simply add an XSLT at `/feed.xslt.xml` and Jekyll Feed will link to the stylesheet.
+Want to style what your feed looks like in the browser? When a XSLT Styleheet file named `feed.xslt.xml`exisrs at the root of your repository, a link to this stylesheet is added to the generated feed.
 
 ## Why Atom, and not RSS?
 

--- a/README.md
+++ b/README.md
@@ -182,6 +182,21 @@ feed:
         - updates
 ```
 
+## Excerpt Only flag
+
+Optional flag `excerpt_only` allows you to exclude post content from the Atom feed. Default value is `false` for backward compatibility.
+
+When in `config.yml` is `true` than all posts in feed will be without `<content>` tags.
+
+```yml
+feed:
+  excerpt_only: true
+```
+
+The same flag can be used directly in post file. It will be disable `<content>` tag for selected post.
+Settings in post file has higher priority than in config file.
+
+
 ## Contributing
 
 1. Fork it (https://github.com/jekyll/jekyll-feed/fork)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,10 +4,10 @@ build: off
 
 environment:
   NOKOGIRI_USE_SYSTEM_LIBRARIES: true
-  JEKYLL_VERSION: "~> 3.8"
+  JEKYLL_VERSION: "~> 3.9"
   matrix:
     - RUBY_FOLDER_VER: "26"
-      JEKYLL_VERSION : "~> 3.7.4"
+      JEKYLL_VERSION : "~> 3.8.6"
     - RUBY_FOLDER_VER: "26"
       JEKYLL_VERSION : ">= 4.0.0.pre.alpha1"
     - RUBY_FOLDER_VER: "26"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,6 @@ environment:
       JEKYLL_VERSION : ">= 4.0.0.pre.alpha1"
     - RUBY_FOLDER_VER: "26"
     - RUBY_FOLDER_VER: "24"
-    - RUBY_FOLDER_VER: "23"
 
 install:
   - SET PATH=C:\Ruby%RUBY_FOLDER_VER%-x64\bin;%PATH%

--- a/jekyll-feed.gemspec
+++ b/jekyll-feed.gemspec
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-lib = File.expand_path("lib", __dir__)
-$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require "jekyll-feed/version"
+require_relative "lib/jekyll-feed/version"
 
 Gem::Specification.new do |spec|
   spec.name          = "jekyll-feed"

--- a/jekyll-feed.gemspec
+++ b/jekyll-feed.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.test_files       = spec.files.grep(%r!^spec/!)
   spec.require_paths    = ["lib"]
 
-  spec.required_ruby_version = ">= 2.3.0"
+  spec.required_ruby_version = ">= 2.4.0"
 
   spec.add_dependency "jekyll", ">= 3.7", "< 5.0"
 

--- a/jekyll-feed.gemspec
+++ b/jekyll-feed.gemspec
@@ -3,17 +3,18 @@
 require_relative "lib/jekyll-feed/version"
 
 Gem::Specification.new do |spec|
-  spec.name          = "jekyll-feed"
-  spec.version       = Jekyll::Feed::VERSION
-  spec.authors       = ["Ben Balter"]
-  spec.email         = ["ben.balter@github.com"]
-  spec.summary       = "A Jekyll plugin to generate an Atom feed of your Jekyll posts"
-  spec.homepage      = "https://github.com/jekyll/jekyll-feed"
-  spec.license       = "MIT"
+  spec.name             = "jekyll-feed"
+  spec.version          = Jekyll::Feed::VERSION
+  spec.authors          = ["Ben Balter"]
+  spec.email            = ["ben.balter@github.com"]
+  spec.summary          = "A Jekyll plugin to generate an Atom feed of your Jekyll posts"
+  spec.homepage         = "https://github.com/jekyll/jekyll-feed"
+  spec.license          = "MIT"
 
-  spec.files         = `git ls-files -z`.split("\x0")
-  spec.test_files    = spec.files.grep(%r!^spec/!)
-  spec.require_paths = ["lib"]
+  spec.files            = Dir["lib/**/*"]
+  spec.extra_rdoc_files = Dir["README.md", "History.markdown", "LICENSE.txt"]
+  spec.test_files       = spec.files.grep(%r!^spec/!)
+  spec.require_paths    = ["lib"]
 
   spec.required_ruby_version = ">= 2.3.0"
 

--- a/lib/jekyll-feed/feed.xml
+++ b/lib/jekyll-feed/feed.xml
@@ -89,6 +89,7 @@
           {% assign post_image = post_image | absolute_url %}
         {% endunless %}
         <media:thumbnail xmlns:media="http://search.yahoo.com/mrss/" url="{{ post_image | xml_escape }}" />
+        <media:content medium="image" url="{{ post_image | xml_escape }}" xmlns:media="http://search.yahoo.com/mrss/" />
       {% endif %}
     </entry>
   {% endfor %}

--- a/lib/jekyll-feed/feed.xml
+++ b/lib/jekyll-feed/feed.xml
@@ -39,7 +39,12 @@
     </author>
   {% endif %}
 
-  {% assign posts = site[page.collection] | where_exp: "post", "post.draft != true" | sort: "date" | reverse %}
+  {% if page.tags %}
+    {% assign entries = site.tags[page.tags] %}
+  {% else %}
+    {% assign entries = site[page.collection] %}
+  {% endif %}
+  {% assign posts = entries | where_exp: "post", "post.draft != true" | sort: "date" | reverse %}
   {% if page.category %}
     {% assign posts = posts | where: "category",page.category %}
   {% endif %}

--- a/lib/jekyll-feed/feed.xml
+++ b/lib/jekyll-feed/feed.xml
@@ -43,7 +43,8 @@
   {% if page.category %}
     {% assign posts = posts | where: "category",page.category %}
   {% endif %}
-  {% for post in posts limit: 10 %}
+  {% assign posts_limit = site.feed.posts_limit | default: 10 %}
+  {% for post in posts limit: posts_limit %}
     <entry{% if post.lang %}{{" "}}xml:lang="{{ post.lang }}"{% endif %}>
       {% assign post_title = post.title | smartify | strip_html | normalize_whitespace | xml_escape %}
 

--- a/lib/jekyll-feed/feed.xml
+++ b/lib/jekyll-feed/feed.xml
@@ -50,7 +50,10 @@
       <published>{{ post.date | date_to_xmlschema }}</published>
       <updated>{{ post.last_modified_at | default: post.date | date_to_xmlschema }}</updated>
       <id>{{ post.id | absolute_url | xml_escape }}</id>
-      <content type="html" xml:base="{{ post.url | absolute_url | xml_escape }}">{{ post.content | strip | xml_escape }}</content>
+      {% assign excerpt_only = post.feed.excerpt_only | default: site.feed.excerpt_only %}
+      {% unless excerpt_only %}
+        <content type="html" xml:base="{{ post.url | absolute_url | xml_escape }}">{{ post.content | strip | xml_escape }}</content>
+      {% endunless %}
 
       {% assign post_author = post.author | default: post.authors[0] | default: site.author %}
       {% assign post_author = site.data.authors[post_author] | default: post_author %}

--- a/lib/jekyll-feed/feed.xml
+++ b/lib/jekyll-feed/feed.xml
@@ -76,6 +76,10 @@
 
       {% if post.category %}
         <category term="{{ post.category | xml_escape }}" />
+      {% elsif post.categories %}
+        {% for category in post.categories %}
+          <category term="{{ category | xml_escape }}" />
+        {% endfor %}
       {% endif %}
 
       {% for tag in post.tags %}

--- a/lib/jekyll-feed/feed.xml
+++ b/lib/jekyll-feed/feed.xml
@@ -40,14 +40,17 @@
   {% endif %}
 
   {% if page.tags %}
-    {% assign entries = site.tags[page.tags] %}
+    {% assign posts = site.tags[page.tags] %}
   {% else %}
-    {% assign entries = site[page.collection] %}
+    {% assign posts = site[page.collection] %}
   {% endif %}
-  {% assign posts = entries | where_exp: "post", "post.draft != true" | sort: "date" | reverse %}
   {% if page.category %}
-    {% assign posts = posts | where: "category",page.category %}
+    {% assign posts = posts | where: "category", page.category %}
   {% endif %}
+  {% unless site.show_drafts %}
+    {% assign posts = posts | where_exp: "post", "post.draft != true" %}
+  {% endunless %}
+  {% assign posts = posts | sort: "date" | reverse %}
   {% assign posts_limit = site.feed.posts_limit | default: 10 %}
   {% for post in posts limit: posts_limit %}
     <entry{% if post.lang %}{{" "}}xml:lang="{{ post.lang }}"{% endif %}>

--- a/lib/jekyll-feed/feed.xml
+++ b/lib/jekyll-feed/feed.xml
@@ -45,8 +45,10 @@
   {% endif %}
   {% for post in posts limit: 10 %}
     <entry{% if post.lang %}{{" "}}xml:lang="{{ post.lang }}"{% endif %}>
-      <title type="html">{{ post.title | smartify | strip_html | normalize_whitespace | xml_escape }}</title>
-      <link href="{{ post.url | absolute_url }}" rel="alternate" type="text/html" title="{{ post.title | xml_escape }}" />
+      {% assign post_title = post.title | smartify | strip_html | normalize_whitespace | xml_escape %}
+
+      <title type="html">{{ post_title }}</title>
+      <link href="{{ post.url | absolute_url }}" rel="alternate" type="text/html" title="{{ post_title }}" />
       <published>{{ post.date | date_to_xmlschema }}</published>
       <updated>{{ post.last_modified_at | default: post.date | date_to_xmlschema }}</updated>
       <id>{{ post.id | absolute_url | xml_escape }}</id>

--- a/lib/jekyll-feed/feed.xml
+++ b/lib/jekyll-feed/feed.xml
@@ -86,7 +86,7 @@
           {% assign post_image = post_image | absolute_url %}
         {% endunless %}
         <media:thumbnail xmlns:media="http://search.yahoo.com/mrss/" url="{{ post_image | xml_escape }}" />
-        <media:content xmlns:media="http://search.yahoo.com/mrss/" url="{{ post_image | xml_escape }}" medium="image" />
+        <media:content xmlns:media="http://search.yahoo.com/mrss/" url="{{ post_image | xml_escape }}" medium="image" width="100%" />
       {% endif %}
     </entry>
   {% endfor %}

--- a/lib/jekyll-feed/generator.rb
+++ b/lib/jekyll-feed/generator.rb
@@ -86,7 +86,7 @@ module JekyllFeed
       tags_pool.each do |tag|
         # allow only tags with basic alphanumeric characters and underscore to keep
         # feed path simple.
-        next if tag =~ %r![^a-zA-Z0-9_]!
+        next if %r![^a-zA-Z0-9_]!.match?(tag)
 
         Jekyll.logger.info "Jekyll Feed:", "Generating feed for posts tagged #{tag}"
         path = "#{tags_path}#{tag}.xml"

--- a/lib/jekyll-feed/meta-tag.rb
+++ b/lib/jekyll-feed/meta-tag.rb
@@ -7,7 +7,7 @@ module JekyllFeed
 
     def render(context)
       @context = context
-      attrs    = attributes.map { |k, v| %(#{k}="#{v}") }.join(" ")
+      attrs    = attributes.map { |k, v| %(#{k}=#{v.encode(:xml => :attr)}) }.join(" ")
       "<link #{attrs} />"
     end
 

--- a/lib/jekyll-feed/meta-tag.rb
+++ b/lib/jekyll-feed/meta-tag.rb
@@ -7,8 +7,11 @@ module JekyllFeed
 
     def render(context)
       @context = context
-      attrs    = attributes.map { |k, v| %(#{k}=#{v.encode(:xml => :attr)}) }.join(" ")
-      "<link #{attrs} />"
+      attrs    = attributes.map do |k, v|
+        v = v.to_s unless v.respond_to?(:encode)
+        %(#{k}=#{v.encode(:xml => :attr)})
+      end
+      "<link #{attrs.join(" ")} />"
     end
 
     private

--- a/lib/jekyll-feed/version.rb
+++ b/lib/jekyll-feed/version.rb
@@ -2,6 +2,6 @@
 
 module Jekyll
   module Feed
-    VERSION = "0.15.0"
+    VERSION = "0.15.1"
   end
 end

--- a/lib/jekyll-feed/version.rb
+++ b/lib/jekyll-feed/version.rb
@@ -2,6 +2,6 @@
 
 module Jekyll
   module Feed
-    VERSION = "0.12.1"
+    VERSION = "0.13.0"
   end
 end

--- a/lib/jekyll-feed/version.rb
+++ b/lib/jekyll-feed/version.rb
@@ -2,6 +2,6 @@
 
 module Jekyll
   module Feed
-    VERSION = "0.13.0"
+    VERSION = "0.14.0"
   end
 end

--- a/lib/jekyll-feed/version.rb
+++ b/lib/jekyll-feed/version.rb
@@ -2,6 +2,6 @@
 
 module Jekyll
   module Feed
-    VERSION = "0.14.0"
+    VERSION = "0.15.0"
   end
 end

--- a/spec/fixtures/_posts/2013-12-12-dec-the-second.md
+++ b/spec/fixtures/_posts/2013-12-12-dec-the-second.md
@@ -2,6 +2,8 @@
 excerpt: "Foo"
 image: "/image.png"
 category: news
+tags:
+ - test
 ---
 
 # December the twelfth, actually.

--- a/spec/fixtures/_posts/2014-03-02-march-the-second.md
+++ b/spec/fixtures/_posts/2014-03-02-march-the-second.md
@@ -1,8 +1,6 @@
 ---
 image: https://cdn.example.org/absolute.png?h=188&w=250
 category: news
-tags:
- - test
 ---
 
 March the second!

--- a/spec/fixtures/_posts/2014-03-02-march-the-second.md
+++ b/spec/fixtures/_posts/2014-03-02-march-the-second.md
@@ -1,6 +1,8 @@
 ---
 image: https://cdn.example.org/absolute.png?h=188&w=250
 category: news
+tags:
+ - test
 ---
 
 March the second!

--- a/spec/fixtures/_posts/2014-03-04-march-the-fourth.md
+++ b/spec/fixtures/_posts/2014-03-04-march-the-fourth.md
@@ -3,7 +3,7 @@ tags:
  - '"/><VADER>'
 image:
   path: "/object-image.png"
-category: updates
+categories: updates jekyll
 ---
 
 March the fourth!

--- a/spec/fixtures/_posts/2014-03-04-march-the-fourth.md
+++ b/spec/fixtures/_posts/2014-03-04-march-the-fourth.md
@@ -2,6 +2,7 @@
 title: <span class="highlight">Sparkling</span> Title
 tags:
  - '"/><VADER>'
+ - test
 image:
   path: "/object-image.png"
 categories: updates jekyll

--- a/spec/fixtures/_posts/2014-03-04-march-the-fourth.md
+++ b/spec/fixtures/_posts/2014-03-04-march-the-fourth.md
@@ -1,4 +1,5 @@
 ---
+title: <span class="highlight">Sparkling</span> Title
 tags:
  - '"/><VADER>'
 image:

--- a/spec/fixtures/_posts/2015-01-18-jekyll-last-modified-at.md
+++ b/spec/fixtures/_posts/2015-01-18-jekyll-last-modified-at.md
@@ -1,5 +1,8 @@
 ---
 last_modified_at: 2015-05-12T13:27:59+00:00
+tags:
+ - test
+ - fail
 ---
 
 Please don't modify this file. It's modified time is important.

--- a/spec/fixtures/_posts/2015-05-12-liquid.md
+++ b/spec/fixtures/_posts/2015-05-12-liquid.md
@@ -1,4 +1,5 @@
 ---
+categories: [first, second, third]
 ---
 
 {% capture liquidstring %}

--- a/spec/fixtures/_posts/2015-05-12-pre.html
+++ b/spec/fixtures/_posts/2015-05-12-pre.html
@@ -1,6 +1,8 @@
 ---
 author: Pat
 lang: en
+tags:
+ - test
 ---
 
 <pre>Line 1

--- a/spec/fixtures/_posts/2015-05-18-author-detail.md
+++ b/spec/fixtures/_posts/2015-05-18-author-detail.md
@@ -4,6 +4,9 @@ author:
   name: Ben
   uri: "http://ben.balter.com"
   email: ben@example.com
+tags:
+ - test
+ - success
 ---
 
 # December the twelfth, actually.

--- a/spec/fixtures/_posts/2015-08-08-stuck-in-the-middle.html
+++ b/spec/fixtures/_posts/2015-08-08-stuck-in-the-middle.html
@@ -1,4 +1,7 @@
 ---
+tags:
+ - test
+ - fail
 feed:
   excerpt_only: true
 ---

--- a/spec/fixtures/_posts/2015-08-08-stuck-in-the-middle.html
+++ b/spec/fixtures/_posts/2015-08-08-stuck-in-the-middle.html
@@ -1,2 +1,6 @@
 ---
+feed:
+  excerpt_only: true
 ---
+
+This content should not be in feed.

--- a/spec/jekyll-feed_spec.rb
+++ b/spec/jekyll-feed_spec.rb
@@ -471,4 +471,42 @@ describe(JekyllFeed) do
       end
     end
   end
+
+  context "excerpt_only flag" do
+    context "backward compatibility for no excerpt_only flag" do
+      it "should be in contents" do
+        expect(contents).to match '<content '
+      end
+    end
+
+    context "when site.excerpt_only flag is true" do
+      let(:overrides) do
+        { "feed" => { "excerpt_only" => true } }
+      end
+
+      it "should not set any contents" do
+        expect(contents).to_not match '<content '
+      end
+    end
+
+    context "when site.excerpt_only flag is false" do
+      let(:overrides) do
+        { "feed" => { "excerpt_only" => false } }
+      end
+
+      it "should be in contents" do
+        expect(contents).to match '<content '
+      end
+    end
+
+    context "when post.excerpt_only flag is true" do
+      let(:overrides) do
+        { "feed" => { "excerpt_only" => false } }
+      end
+
+      it "should not be in contents" do
+        expect(contents).to_not match "This content should not be in feed.</content>"
+      end
+    end
+  end
 end

--- a/spec/jekyll-feed_spec.rb
+++ b/spec/jekyll-feed_spec.rb
@@ -189,6 +189,21 @@ describe(JekyllFeed) do
       end
     end
 
+    context "with site.title set as a non-string value" do
+      class MySiteTitle
+        def to_s
+          "My Dynamic Site Title <&>"
+        end
+        alias_method :to_liquid, :to_s
+      end
+      let(:site_title) { MySiteTitle.new }
+      let(:overrides) { { "title" => site_title } }
+
+      it "ensures the site.title is the string representation of the object" do
+        expect(feed.title.content).to eql(site_title.to_s.encode(xml: :text))
+      end
+    end
+
     context "with site.name set" do
       let(:site_name) { "My Site Name" }
       let(:overrides) { { "name" => site_name } }

--- a/spec/jekyll-feed_spec.rb
+++ b/spec/jekyll-feed_spec.rb
@@ -87,6 +87,10 @@ describe(JekyllFeed) do
     expect(contents).to match '<title type="html">The plugin will properly strip newlines.</title>'
   end
 
+  it "strips HTML from link titles" do
+    expect(contents).to match %r!<link .* title="Sparkling Title" />!
+  end
+
   it "renders Liquid inside posts" do
     expect(contents).to match "Liquid is rendered."
     expect(contents).not_to match "Liquid is not rendered."

--- a/spec/jekyll-feed_spec.rb
+++ b/spec/jekyll-feed_spec.rb
@@ -207,6 +207,15 @@ describe(JekyllFeed) do
         expect(feed.title.content).to eql(site_title)
       end
     end
+
+    context "with site.title has special characters" do
+      let(:site_title) { "My Site Title <&>" }
+      let(:overrides) { { "title" => site_title } }
+
+      it "uses encoded site.title for the title" do
+        expect(feed.title.content).to eql(site_title.encode(xml: :text))
+      end
+    end
   end
 
   context "smartify" do

--- a/spec/jekyll-feed_spec.rb
+++ b/spec/jekyll-feed_spec.rb
@@ -92,10 +92,22 @@ describe(JekyllFeed) do
     expect(contents).not_to match "Liquid is not rendered."
   end
 
-  it "includes the item image" do
-    expect(contents).to include('<media:thumbnail xmlns:media="http://search.yahoo.com/mrss/" url="http://example.org/image.png" />')
-    expect(contents).to include('<media:thumbnail xmlns:media="http://search.yahoo.com/mrss/" url="https://cdn.example.org/absolute.png?h=188&amp;w=250" />')
-    expect(contents).to include('<media:thumbnail xmlns:media="http://search.yahoo.com/mrss/" url="http://example.org/object-image.png" />')
+  context "images" do
+    let(:image1) { 'http://example.org/image.png' }
+    let(:image2) { 'https://cdn.example.org/absolute.png?h=188&amp;w=250' }
+    let(:image3) { 'http://example.org/object-image.png' }
+
+    it "includes the item image" do
+      expect(contents).to include(%(<media:thumbnail xmlns:media="http://search.yahoo.com/mrss/" url="#{image1}" />))
+      expect(contents).to include(%(<media:thumbnail xmlns:media="http://search.yahoo.com/mrss/" url="#{image2}" />))
+      expect(contents).to include(%(<media:thumbnail xmlns:media="http://search.yahoo.com/mrss/" url="#{image3}" />))
+    end
+
+    it "included media content for mail templates (Mailchimp)" do
+      expect(contents).to include(%(<media:content medium="image" url="#{image1}" xmlns:media="http://search.yahoo.com/mrss/" />))
+      expect(contents).to include(%(<media:content medium="image" url="#{image2}" xmlns:media="http://search.yahoo.com/mrss/" />))
+      expect(contents).to include(%(<media:content medium="image" url="#{image3}" xmlns:media="http://search.yahoo.com/mrss/" />))
+    end
   end
 
   context "parsing" do

--- a/spec/jekyll-feed_spec.rb
+++ b/spec/jekyll-feed_spec.rb
@@ -534,4 +534,24 @@ describe(JekyllFeed) do
       end
     end
   end
+
+  context "with feed.posts_limit set to 2" do
+    let(:overrides) do
+      { "feed" => { "posts_limit" => 2 } }
+    end
+
+    it "puts the latest 2 the posts in the feed.xml file" do
+      expect(contents).to_not match "http://example.org/news/2013/12/12/dec-the-second.html"
+      expect(contents).to_not match "http://example.org/news/2014/03/02/march-the-second.html"
+      expect(contents).to_not match "http://example.org/updates/jekyll/2014/03/04/march-the-fourth.html"
+      expect(contents).to_not match "http://example.org/2015/01/18/jekyll-last-modified-at.html"
+      expect(contents).to_not match "http://example.org/2015/02/12/strip-newlines.html"
+      expect(contents).to_not match "http://example.org/2015/05/12/liquid.html"
+      expect(contents).to_not match "http://example.org/2015/05/12/pre.html"
+      expect(contents).to_not match "http://example.org/2015/05/18/author-detail.html"
+
+      expect(contents).to match "http://example.org/2015/08/08/stuck-in-the-middle.html"
+      expect(contents).to match "http://example.org/2016/04/25/author-reference.html"
+    end
+  end
 end

--- a/spec/jekyll-feed_spec.rb
+++ b/spec/jekyll-feed_spec.rb
@@ -9,7 +9,7 @@ describe(JekyllFeed) do
       "full_rebuild" => true,
       "source"       => source_dir,
       "destination"  => dest_dir,
-      "show_drafts"  => true,
+      "show_drafts"  => false,
       "url"          => "http://example.org",
       "name"         => "My awesome site",
       "author"       => {
@@ -699,6 +699,28 @@ describe(JekyllFeed) do
 
       expect(contents).to match "http://example.org/2015/08/08/stuck-in-the-middle.html"
       expect(contents).to match "http://example.org/2016/04/25/author-reference.html"
+    end
+  end
+
+  context "support drafts" do
+    context "with disable show_drafts option" do
+      let(:overrides) do
+        { "show_drafts" => false }
+      end
+
+      it "should not be draft post" do
+        expect(contents).to_not match "a-draft.html"
+      end
+    end
+
+    context "with enable show_drafts option" do
+      let(:overrides) do
+        { "show_drafts" => true }
+      end
+
+      it "should be draft post" do
+        expect(contents).to match "a-draft.html"
+      end
     end
   end
 end

--- a/spec/jekyll-feed_spec.rb
+++ b/spec/jekyll-feed_spec.rb
@@ -316,6 +316,19 @@ describe(JekyllFeed) do
     end
   end
 
+  context "with 'categories' or 'category' or 'tags' key in the front matter" do
+    let(:feed) { RSS::Parser.parse(contents) }
+    let(:entry_with_single_category) { feed.items.find { |i| i.title.content == "March The Second" } }
+    let(:entry_with_multiple_categories) { feed.items.find { |i| i.title.content == "Liquid" } }
+    let(:entry_with_multiple_categories_and_tags) { feed.items.find { |i| i.title.content == "Sparkling Title" } }
+
+    it "generates the feed correctly" do
+      expect(entry_with_single_category.categories.map(&:term)).to eql(%w(news))
+      expect(entry_with_multiple_categories.categories.map(&:term)).to eql(%w(first second third))
+      expect(entry_with_multiple_categories_and_tags.categories.map(&:term)).to eql(["updates", "jekyll", "\"/><VADER>", "test"])
+    end
+  end
+
   context "changing the file path via collection meta" do
     let(:overrides) do
       {
@@ -526,7 +539,6 @@ describe(JekyllFeed) do
         expect(Pathname.new(dest_dir("feed/by_tag/success.xml"))).to exist
 
         expect(tags_feed_test).to match "/2013/12/12/dec-the-second.html"
-        expect(tags_feed_test).to match "/2014/03/02/march-the-second.html"
         expect(tags_feed_test).to match "/2014/03/04/march-the-fourth.html"
         expect(tags_feed_test).to match "/2015/01/18/jekyll-last-modified-at.html"
         expect(tags_feed_test).to match "/2015/05/12/pre.html"

--- a/spec/jekyll-feed_spec.rb
+++ b/spec/jekyll-feed_spec.rb
@@ -43,7 +43,7 @@ describe(JekyllFeed) do
   end
 
   it "puts all the posts in the feed.xml file" do
-    expect(contents).to match "http://example.org/updates/2014/03/04/march-the-fourth.html"
+    expect(contents).to match "http://example.org/updates/jekyll/2014/03/04/march-the-fourth.html"
     expect(contents).to match "http://example.org/news/2014/03/02/march-the-second.html"
     expect(contents).to match "http://example.org/news/2013/12/12/dec-the-second.html"
     expect(contents).to match "http://example.org/2015/08/08/stuck-in-the-middle.html"
@@ -240,7 +240,7 @@ describe(JekyllFeed) do
     end
 
     it "correctly adds the baseurl to the posts" do
-      expect(contents).to match "http://example.org/bass/updates/2014/03/04/march-the-fourth.html"
+      expect(contents).to match "http://example.org/bass/updates/jekyll/2014/03/04/march-the-fourth.html"
       expect(contents).to match "http://example.org/bass/news/2014/03/02/march-the-second.html"
       expect(contents).to match "http://example.org/bass/news/2013/12/12/dec-the-second.html"
     end
@@ -345,7 +345,7 @@ describe(JekyllFeed) do
       let(:news_feed) { File.read(dest_dir("feed/news.xml")) }
 
       it "outputs the primary feed" do
-        expect(contents).to match "http://example.org/updates/2014/03/04/march-the-fourth.html"
+        expect(contents).to match "http://example.org/updates/jekyll/2014/03/04/march-the-fourth.html"
         expect(contents).to match "http://example.org/news/2014/03/02/march-the-second.html"
         expect(contents).to match "http://example.org/news/2013/12/12/dec-the-second.html"
         expect(contents).to match "http://example.org/2015/08/08/stuck-in-the-middle.html"
@@ -356,7 +356,7 @@ describe(JekyllFeed) do
         expect(news_feed).to match '<title type="html">My awesome site | News</title>'
         expect(news_feed).to match "http://example.org/news/2014/03/02/march-the-second.html"
         expect(news_feed).to match "http://example.org/news/2013/12/12/dec-the-second.html"
-        expect(news_feed).to_not match "http://example.org/updates/2014/03/04/march-the-fourth.html"
+        expect(news_feed).to_not match "http://example.org/updates/jekyll/2014/03/04/march-the-fourth.html"
         expect(news_feed).to_not match "http://example.org/2015/08/08/stuck-in-the-middle.html"
       end
     end
@@ -376,7 +376,7 @@ describe(JekyllFeed) do
       let(:news_feed) { File.read(dest_dir("feed/news.xml")) }
 
       it "outputs the primary feed" do
-        expect(contents).to match "http://example.org/updates/2014/03/04/march-the-fourth.html"
+        expect(contents).to match "http://example.org/updates/jekyll/2014/03/04/march-the-fourth.html"
         expect(contents).to match "http://example.org/news/2014/03/02/march-the-second.html"
         expect(contents).to match "http://example.org/news/2013/12/12/dec-the-second.html"
         expect(contents).to match "http://example.org/2015/08/08/stuck-in-the-middle.html"
@@ -387,7 +387,7 @@ describe(JekyllFeed) do
         expect(news_feed).to match '<title type="html">My awesome site | News</title>'
         expect(news_feed).to match "http://example.org/news/2014/03/02/march-the-second.html"
         expect(news_feed).to match "http://example.org/news/2013/12/12/dec-the-second.html"
-        expect(news_feed).to_not match "http://example.org/updates/2014/03/04/march-the-fourth.html"
+        expect(news_feed).to_not match "http://example.org/updates/jekyll/2014/03/04/march-the-fourth.html"
         expect(news_feed).to_not match "http://example.org/2015/08/08/stuck-in-the-middle.html"
       end
     end
@@ -412,7 +412,7 @@ describe(JekyllFeed) do
         expect(collection_feed).to match '<title type="html">My awesome site | Collection</title>'
         expect(collection_feed).to match "http://example.org/collection/2018-01-01-collection-doc.html"
         expect(collection_feed).to match "http://example.org/collection/2018-01-02-collection-category-doc.html"
-        expect(collection_feed).to_not match "http://example.org/updates/2014/03/04/march-the-fourth.html"
+        expect(collection_feed).to_not match "http://example.org/updates/jekyll/2014/03/04/march-the-fourth.html"
         expect(collection_feed).to_not match "http://example.org/2015/08/08/stuck-in-the-middle.html"
       end
     end
@@ -440,7 +440,7 @@ describe(JekyllFeed) do
         expect(news_feed).to match '<title type="html">My awesome site | Collection | News</title>'
         expect(news_feed).to match "http://example.org/collection/2018-01-02-collection-category-doc.html"
         expect(news_feed).to_not match "http://example.org/collection/2018-01-01-collection-doc.html"
-        expect(news_feed).to_not match "http://example.org/updates/2014/03/04/march-the-fourth.html"
+        expect(news_feed).to_not match "http://example.org/updates/jekyll/2014/03/04/march-the-fourth.html"
         expect(news_feed).to_not match "http://example.org/2015/08/08/stuck-in-the-middle.html"
       end
     end

--- a/spec/jekyll-feed_spec.rb
+++ b/spec/jekyll-feed_spec.rb
@@ -497,6 +497,141 @@ describe(JekyllFeed) do
     end
   end
 
+  context "tags" do
+    let(:tags_feed_test) { File.read(dest_dir("feed/by_tag/test.xml")) }
+    let(:tags_feed_fail) { File.read(dest_dir("feed/by_tag/fail.xml")) }
+    let(:tags_feed_success) { File.read(dest_dir("feed/by_tag/success.xml")) }
+
+
+    context "do not set tags setting" do
+      it "should not write tags feeds" do
+        expect(Pathname.new(dest_dir("feed/by_tag/test.xml"))).to_not exist
+        expect(Pathname.new(dest_dir("feed/by_tag/fail.xml"))).to_not exist
+        expect(Pathname.new(dest_dir("feed/by_tag/success.xml"))).to_not exist
+      end
+    end
+
+    context "set tags setting" do
+      let(:overrides) do
+        {
+          "feed" => {
+            "tags" => true
+          },
+        }
+      end
+
+      it "should write tags feeds" do
+        expect(Pathname.new(dest_dir("feed/by_tag/test.xml"))).to exist
+        expect(Pathname.new(dest_dir("feed/by_tag/fail.xml"))).to exist
+        expect(Pathname.new(dest_dir("feed/by_tag/success.xml"))).to exist
+
+        expect(tags_feed_test).to match "/2013/12/12/dec-the-second.html"
+        expect(tags_feed_test).to match "/2014/03/02/march-the-second.html"
+        expect(tags_feed_test).to match "/2014/03/04/march-the-fourth.html"
+        expect(tags_feed_test).to match "/2015/01/18/jekyll-last-modified-at.html"
+        expect(tags_feed_test).to match "/2015/05/12/pre.html"
+        expect(tags_feed_test).to match "/2015/05/18/author-detail.html"
+        expect(tags_feed_test).to match "/2015/08/08/stuck-in-the-middle.html"
+
+        expect(tags_feed_fail).to match "/2015/01/18/jekyll-last-modified-at.html"
+        expect(tags_feed_fail).to match "/2015/08/08/stuck-in-the-middle.html"
+        expect(tags_feed_fail).to_not match "/2013/12/12/dec-the-second.html"
+        expect(tags_feed_fail).to_not match "/2014/03/02/march-the-second.html"
+        expect(tags_feed_fail).to_not match "/2014/03/04/march-the-fourth.html"
+        expect(tags_feed_fail).to_not match "/2015/05/12/pre.html"
+        expect(tags_feed_fail).to_not match "/2015/05/18/author-detail.html"
+
+        expect(tags_feed_success).to match "2015/05/18/author-detail.html"
+        expect(tags_feed_success).to_not match "/2013/12/12/dec-the-second.html"
+        expect(tags_feed_success).to_not match "/2014/03/02/march-the-second.html"
+        expect(tags_feed_success).to_not match "/2014/03/04/march-the-fourth.html"
+        expect(tags_feed_success).to_not match "/2015/01/18/jekyll-last-modified-at.html"
+        expect(tags_feed_success).to_not match "/2015/05/12/pre.html"
+        expect(tags_feed_success).to_not match "/2015/08/08/stuck-in-the-middle.html"
+      end
+    end
+
+    context "set exclusions" do
+      let(:overrides) do
+        {
+          "feed" => {
+            "tags" => {
+              "except" => ["fail"]
+            },
+          },
+        }
+      end
+
+      it "should not write fail feed" do
+        expect(Pathname.new(dest_dir("feed/by_tag/test.xml"))).to exist
+        expect(Pathname.new(dest_dir("feed/by_tag/fail.xml"))).to_not exist
+        expect(Pathname.new(dest_dir("feed/by_tag/success.xml"))).to exist
+      end
+    end
+
+    context "set inclusions" do
+      let(:overrides) do
+        {
+          "feed" => {
+            "tags" => {
+              "only" => ["success"]
+            },
+          },
+        }
+      end
+
+      it "should not write fail feed" do
+        expect(Pathname.new(dest_dir("feed/by_tag/test.xml"))).to_not exist
+        expect(Pathname.new(dest_dir("feed/by_tag/fail.xml"))).to_not exist
+        expect(Pathname.new(dest_dir("feed/by_tag/success.xml"))).to exist
+      end
+    end
+
+    context "set alternate path" do
+      let(:overrides) do
+        {
+          "feed" => {
+            "tags" => {
+              "path" => "alternate/path/"
+            },
+          },
+        }
+      end
+
+      it "should write feeds to new path" do
+        expect(Pathname.new(dest_dir("feed/by_tag/test.xml"))).to_not exist
+        expect(Pathname.new(dest_dir("feed/by_tag/fail.xml"))).to_not exist
+        expect(Pathname.new(dest_dir("feed/by_tag/success.xml"))).to_not exist
+
+        expect(Pathname.new(dest_dir("alternate/path/test.xml"))).to exist
+        expect(Pathname.new(dest_dir("alternate/path/fail.xml"))).to exist
+        expect(Pathname.new(dest_dir("alternate/path/success.xml"))).to exist
+      end
+
+      context "set to questionable path" do
+        let(:overrides) do
+          {
+            "feed" => {
+              "tags" => {
+                "path" => "../../../../../../../questionable/path/"
+              },
+            },
+          }
+        end
+
+        it "should write feeds to sane paths" do
+          expect(Pathname.new(dest_dir("feed/by_tag/test.xml"))).to_not exist
+          expect(Pathname.new(dest_dir("feed/by_tag/fail.xml"))).to_not exist
+          expect(Pathname.new(dest_dir("feed/by_tag/success.xml"))).to_not exist
+
+          expect(Pathname.new(dest_dir("questionable/path/test.xml"))).to exist
+          expect(Pathname.new(dest_dir("questionable/path/fail.xml"))).to exist
+          expect(Pathname.new(dest_dir("questionable/path/success.xml"))).to exist
+        end
+      end
+    end
+  end
+
   context "excerpt_only flag" do
     context "backward compatibility for no excerpt_only flag" do
       it "should be in contents" do


### PR DESCRIPTION
Pull latest changes from jekyll/jekyll-feed, for compatibility with jekyll-theme-cloudcannon 0.1.3 (which depends on jekyll-feed ~> 0.15.0).